### PR TITLE
Add UI language switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This add-on scans your Home Assistant server and ecosystem for security vulnerab
 - 🧩 Home Assistant config security parser (`configuration.yaml`)
 - 🖥️ SSH terminal add-on check (auth & exposure)
 - 🌐 Web-based interface with multilingual support (🇬🇧 English / 🇳🇱 Dutch)
+  - Use the language selector at the top of the dashboard to switch translations
 - 📝 Per-module logs + downloadable full report
 
 ### 🧠 Built with

--- a/hass_security_dashboard/front/assets/app.js
+++ b/hass_security_dashboard/front/assets/app.js
@@ -1,11 +1,48 @@
+let translations = {};
+let lastScanData = null;
+
+function loadLanguage(lang) {
+    return fetch(`assets/${lang}.json`)
+        .then(resp => resp.json())
+        .then(data => {
+            translations = data;
+            document.title = data.title;
+            document.getElementById('appName').innerText = data.appName;
+            document.getElementById('runScan').innerText = data.runScan;
+            document.getElementById('langLabel').innerText = data.language + ':';
+        });
+}
+
+function switchLanguage(lang) {
+    loadLanguage(lang).then(() => {
+        if (lastScanData) {
+            displayScanResults(lastScanData);
+        }
+        localStorage.setItem('lang', lang);
+        document.getElementById('lang-select').value = lang;
+    });
+}
+
+function displayScanResults(data) {
+    document.getElementById('score').innerHTML =
+        translations.openPorts + ': ' + data.scan.open_ports.join(', ') +
+        '<br>' + translations.sslDaysLeft + ': ' + data.scan.ssl_days_left +
+        '<br>' + translations.mqttSecure + ': ' + data.scan.mqtt_secure +
+        '<br>' + translations.cloudflareProtected + ': ' + data.scan.cloudflare_protected;
+    document.getElementById('recommendations').innerHTML =
+        translations.recommendations + ':<br>' + data.recommendations.join('<br>');
+}
+
 function scan() {
     fetch('/scan', {method: 'POST'})
     .then(response => response.json())
     .then(data => {
-        document.getElementById('score').innerHTML = 'Open Ports: ' + data.scan.open_ports.join(', ') +
-            '<br>SSL Days Left: ' + data.scan.ssl_days_left +
-            '<br>MQTT Secure: ' + data.scan.mqtt_secure +
-            '<br>Cloudflare Protected: ' + data.scan.cloudflare_protected;
-        document.getElementById('recommendations').innerHTML = 'Recommendations:<br>' + data.recommendations.join('<br>');
+        lastScanData = data;
+        displayScanResults(data);
     });
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+    const lang = localStorage.getItem('lang') || 'en';
+    switchLanguage(lang);
+});

--- a/hass_security_dashboard/front/assets/en.json
+++ b/hass_security_dashboard/front/assets/en.json
@@ -1,0 +1,11 @@
+{
+  "title": "Security Dashboard",
+  "appName": "HassSecurityDashboard",
+  "runScan": "Run Security Scan",
+  "language": "Language",
+  "openPorts": "Open Ports",
+  "sslDaysLeft": "SSL Days Left",
+  "mqttSecure": "MQTT Secure",
+  "cloudflareProtected": "Cloudflare Protected",
+  "recommendations": "Recommendations"
+}

--- a/hass_security_dashboard/front/assets/nl.json
+++ b/hass_security_dashboard/front/assets/nl.json
@@ -1,0 +1,11 @@
+{
+  "title": "Beveiligingsdashboard",
+  "appName": "HassSecurityDashboard",
+  "runScan": "Beveiligingsscan uitvoeren",
+  "language": "Taal",
+  "openPorts": "Open poorten",
+  "sslDaysLeft": "SSL-dagen resterend",
+  "mqttSecure": "MQTT beveiligd",
+  "cloudflareProtected": "Cloudflare beveiligd",
+  "recommendations": "Aanbevelingen"
+}

--- a/hass_security_dashboard/front/index.html
+++ b/hass_security_dashboard/front/index.html
@@ -6,8 +6,15 @@
     <link rel="stylesheet" href="assets/styles.css">
 </head>
 <body>
-    <h1>HassSecurityDashboard</h1>
-    <button onclick="scan()">Run Security Scan</button>
+    <h1 id="appName"></h1>
+    <div>
+        <label id="langLabel" for="lang-select">Language:</label>
+        <select id="lang-select" onchange="switchLanguage(this.value)">
+            <option value="en">English</option>
+            <option value="nl">Nederlands</option>
+        </select>
+    </div>
+    <button id="runScan" onclick="scan()"></button>
     <div id="score"></div>
     <div id="recommendations"></div>
     <script src="assets/app.js"></script>


### PR DESCRIPTION
## Summary
- add English and Dutch translation files
- implement client-side language switching
- show dropdown to switch language
- document how to switch translations

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68448e74fa0083309dd8318f1a10696c