### PR TITLE
Add logging and report download feature

### DIFF
--- a/hass_security_dashboard/back/app.py
+++ b/hass_security_dashboard/back/app.py
@@ -1,7 +1,10 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, send_file
 from security_scanner import perform_full_scan
 from recommender import generate_recommendations
+import logging
+import json
 import os
+from datetime import datetime
 
 app = Flask(__name__)
 
@@ -11,10 +14,23 @@ CLOUDFLARE_API_TOKEN = os.environ.get("CLOUDFLARE_API_TOKEN", "")
 CLOUDFLARE_DOMAIN = os.environ.get("CLOUDFLARE_DOMAIN", "localhost")
 DUCKDNS_DOMAIN = os.environ.get("DUCKDNS_DOMAIN", "")
 CONFIG_PATH = os.environ.get("CONFIG_PATH", "/config/configuration.yaml")
+LOG_DIR = os.path.join(os.path.dirname(__file__), "logs")
+os.makedirs(LOG_DIR, exist_ok=True)
+log_file = os.path.join(LOG_DIR, datetime.now().strftime("%Y%m%d_%H%M%S") + ".log")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+    handlers=[
+        logging.FileHandler(log_file),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger(__name__)
 
 @app.route('/scan', methods=['POST'])
 def scan():
     """Run security scan and return results."""
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     results = perform_full_scan(
         CLOUDFLARE_DOMAIN,
         CLOUDFLARE_API_TOKEN,
@@ -22,7 +38,12 @@ def scan():
         config_path=CONFIG_PATH,
     )
     recommendations = generate_recommendations(results)
-    return jsonify({"scan": results, "recommendations": recommendations})
+    report = {"scan": results, "recommendations": recommendations}
+    json_file = os.path.join(LOG_DIR, f"scan_{timestamp}.json")
+    with open(json_file, "w") as f:
+        json.dump(report, f)
+    logger.info("Scan completed", extra={"results": results})
+    return jsonify(report)
 
 @app.route('/status', methods=['GET'])
 def status():
@@ -33,6 +54,19 @@ def config():
     if request.method == 'POST':
         return jsonify({"message": "Configuration updated."})
     return jsonify({"port": PORT, "use_ingress": True})
+
+@app.route('/report', methods=['GET'])
+def report():
+    """Download the most recent log or scan result."""
+    files = [
+        os.path.join(LOG_DIR, f)
+        for f in os.listdir(LOG_DIR)
+        if f.endswith('.json') or f.endswith('.log')
+    ]
+    if not files:
+        return jsonify({"error": "No reports available."}), 404
+    latest_file = max(files, key=os.path.getmtime)
+    return send_file(latest_file, as_attachment=True)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=PORT)

--- a/hass_security_dashboard/front/assets/app.js
+++ b/hass_security_dashboard/front/assets/app.js
@@ -9,6 +9,9 @@ function loadLanguage(lang) {
             document.title = data.title;
             document.getElementById('appName').innerText = data.appName;
             document.getElementById('runScan').innerText = data.runScan;
+            if (document.getElementById('downloadReport')) {
+                document.getElementById('downloadReport').innerText = data.downloadReport;
+            }
             document.getElementById('langLabel').innerText = data.language + ':';
         });
 }
@@ -33,16 +36,25 @@ function displayScanResults(data) {
         translations.recommendations + ':<br>' + data.recommendations.join('<br>');
 }
 
+function downloadReport() {
+    window.location.href = '/report';
+}
+
 function scan() {
     fetch('/scan', {method: 'POST'})
     .then(response => response.json())
     .then(data => {
         lastScanData = data;
         displayScanResults(data);
+        document.getElementById('downloadReport').style.display = 'inline-block';
     });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     const lang = localStorage.getItem('lang') || 'en';
     switchLanguage(lang);
+    const btn = document.getElementById('downloadReport');
+    if (btn) {
+        btn.style.display = 'none';
+    }
 });

--- a/hass_security_dashboard/front/assets/en.json
+++ b/hass_security_dashboard/front/assets/en.json
@@ -7,5 +7,6 @@
   "sslDaysLeft": "SSL Days Left",
   "mqttSecure": "MQTT Secure",
   "cloudflareProtected": "Cloudflare Protected",
-  "recommendations": "Recommendations"
+  "recommendations": "Recommendations",
+  "downloadReport": "Download Report"
 }

--- a/hass_security_dashboard/front/assets/nl.json
+++ b/hass_security_dashboard/front/assets/nl.json
@@ -7,5 +7,6 @@
   "sslDaysLeft": "SSL-dagen resterend",
   "mqttSecure": "MQTT beveiligd",
   "cloudflareProtected": "Cloudflare beveiligd",
-  "recommendations": "Aanbevelingen"
+  "recommendations": "Aanbevelingen",
+  "downloadReport": "Rapport downloaden"
 }

--- a/hass_security_dashboard/front/index.html
+++ b/hass_security_dashboard/front/index.html
@@ -15,6 +15,7 @@
         </select>
     </div>
     <button id="runScan" onclick="scan()"></button>
+    <button id="downloadReport" onclick="downloadReport()"></button>
     <div id="score"></div>
     <div id="recommendations"></div>
     <script src="assets/app.js"></script>


### PR DESCRIPTION
## Summary
- log to timestamped files
- save scan results as JSON
- serve latest report via `/report`
- add 'Download Report' button after scans

## Testing
- `python -m py_compile hass_security_dashboard/back/app.py hass_security_dashboard/back/security_scanner.py`

------
https://chatgpt.com/codex/tasks/task_e_684490e115b083309f6bc01eee435f76