### PR TITLE
Extend scan result display

### DIFF
--- a/hass_security_dashboard/front/assets/app.js
+++ b/hass_security_dashboard/front/assets/app.js
@@ -27,11 +27,17 @@ function switchLanguage(lang) {
 }
 
 function displayScanResults(data) {
-    document.getElementById('score').innerHTML =
-        translations.openPorts + ': ' + data.scan.open_ports.join(', ') +
-        '<br>' + translations.sslDaysLeft + ': ' + data.scan.ssl_days_left +
-        '<br>' + translations.mqttSecure + ': ' + data.scan.mqtt_secure +
-        '<br>' + translations.cloudflareProtected + ': ' + data.scan.cloudflare_protected;
+    const scan = data.scan;
+    let html =
+        translations.openPorts + ': ' + scan.open_ports.join(', ') +
+        '<br>' + translations.sslDaysLeft + ': ' + scan.ssl_days_left +
+        '<br>' + translations.mqttSecure + ': ' + scan.mqtt_secure +
+        '<br>' + translations.cloudflareProtected + ': ' + scan.cloudflare_protected +
+        '<br>' + translations.duckdnsMatch + ': ' + scan.duckdns_match +
+        '<br>' + translations.configSecurity + ': ' + JSON.stringify(scan.config_security) +
+        '<br>' + translations.sshAddon + ': ' + JSON.stringify(scan.ssh_addon) +
+        '<br>' + translations.coreInfo + ': ' + JSON.stringify(scan.core);
+    document.getElementById('score').innerHTML = html;
     document.getElementById('recommendations').innerHTML =
         translations.recommendations + ':<br>' + data.recommendations.join('<br>');
 }

--- a/hass_security_dashboard/front/assets/en.json
+++ b/hass_security_dashboard/front/assets/en.json
@@ -7,6 +7,10 @@
   "sslDaysLeft": "SSL Days Left",
   "mqttSecure": "MQTT Secure",
   "cloudflareProtected": "Cloudflare Protected",
+  "duckdnsMatch": "DuckDNS Match",
+  "configSecurity": "Config Security",
+  "sshAddon": "SSH Add-on",
+  "coreInfo": "Core Info",
   "recommendations": "Recommendations",
   "downloadReport": "Download Report"
 }

--- a/hass_security_dashboard/front/assets/nl.json
+++ b/hass_security_dashboard/front/assets/nl.json
@@ -7,6 +7,10 @@
   "sslDaysLeft": "SSL-dagen resterend",
   "mqttSecure": "MQTT beveiligd",
   "cloudflareProtected": "Cloudflare beveiligd",
+  "duckdnsMatch": "DuckDNS match",
+  "configSecurity": "Configuratiebeveiliging",
+  "sshAddon": "SSH-add-on",
+  "coreInfo": "Core-info",
   "recommendations": "Aanbevelingen",
   "downloadReport": "Rapport downloaden"
 }


### PR DESCRIPTION
## Summary
- show more scan results in dashboard
- add translation strings

## Testing
- `python3 -m py_compile hass_security_dashboard/back/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6844930903848330b8db12fdf67f5d57