### PR TITLE
Add pytest suite and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ Edit `config.json` or the add-on options in Home Assistant:
 
 > Use this tool to secure your smart home before attackers try to.
 
+
+### Running tests
+Use `pytest` to run the test suite:
+
+```bash
+pytest
+```
+

--- a/hass_security_dashboard/__init__.py
+++ b/hass_security_dashboard/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/hass_security_dashboard/back/__init__.py
+++ b/hass_security_dashboard/back/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/tests/test_ha_cli_utils.py
+++ b/tests/test_ha_cli_utils.py
@@ -1,0 +1,49 @@
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "hass_security_dashboard", "back"))
+
+import pytest
+
+from hass_security_dashboard.back import ha_cli_utils
+
+
+def test_run_ha_command_success():
+    mock_completed = subprocess.CompletedProcess(['ha'], 0, stdout='ok')
+    with patch('subprocess.run', return_value=mock_completed) as run:
+        out = ha_cli_utils.run_ha_command(['core', 'info'])
+        run.assert_called_once()
+        assert out == 'ok'
+
+
+def test_run_ha_command_not_found():
+    with patch('subprocess.run', side_effect=FileNotFoundError):
+        with pytest.raises(ha_cli_utils.HACliUnavailable):
+            ha_cli_utils.run_ha_command(['core', 'info'])
+
+
+def test_run_ha_command_calledprocesserror():
+    with patch('subprocess.run', side_effect=subprocess.CalledProcessError(1, 'ha')):
+        assert ha_cli_utils.run_ha_command(['core', 'info']) is None
+
+
+def test_get_addon_info_success():
+    data = {'version': '1.0', 'update_available': False, 'state': 'started'}
+    with patch('hass_security_dashboard.back.ha_cli_utils.run_ha_command', return_value=json.dumps(data)):
+        info = ha_cli_utils.get_addon_info('core_ssh')
+        assert info['version'] == '1.0'
+        assert info['update_available'] is False
+        assert info['state'] == 'started'
+
+
+def test_get_core_info_success():
+    payload = {'version': '1.0', 'version_latest': '1.1'}
+    with patch('hass_security_dashboard.back.ha_cli_utils.run_ha_command', return_value=json.dumps(payload)):
+        info = ha_cli_utils.get_core_info()
+        assert info['version'] == '1.0'
+        assert info['update_available'] is True

--- a/tests/test_recommender.py
+++ b/tests/test_recommender.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "hass_security_dashboard", "back"))
+
+from hass_security_dashboard.back import recommender
+
+
+def test_generate_recommendations():
+    results = {
+        'ssl_days_left': 10,
+        'open_ports': [22],
+        'mqtt_secure': False,
+        'cloudflare_protected': False
+    }
+    recs = recommender.generate_recommendations(results)
+    assert "Renew SSL certificate soon." in recs
+    assert any("Restrict SSH" in r for r in recs)
+    assert any("Secure your MQTT" in r for r in recs)
+    assert any("Enable Cloudflare" in r for r in recs)

--- a/tests/test_security_scanner.py
+++ b/tests/test_security_scanner.py
@@ -1,0 +1,53 @@
+import tempfile
+import json
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, "hass_security_dashboard", "back"))
+
+sys.modules.setdefault("requests", MagicMock())
+import types
+sys.modules.setdefault("yaml", types.SimpleNamespace(safe_load=lambda data: {}))
+
+from hass_security_dashboard.back import security_scanner as ss
+
+
+def test_parse_configuration(tmp_path):
+    config = tmp_path / 'configuration.yaml'
+    config.write_text('http:\n  ssl_certificate: cert.pem\nmqtt:\n  password: pass')
+    with patch('yaml.safe_load', return_value={'http': {'ssl_certificate': 'cert.pem'}, 'mqtt': {'password': 'pass'}}):
+        result = ss.parse_configuration(str(config))
+    assert result['http_ssl'] is True
+    assert result['mqtt_has_password'] is True
+
+
+def test_parse_configuration_missing_values(tmp_path):
+    config = tmp_path / 'configuration.yaml'
+    config.write_text('http: {}\nmqtt: {}')
+    with patch('yaml.safe_load', return_value={'http': {}, 'mqtt': {}}):
+        result = ss.parse_configuration(str(config))
+    assert result['http_ssl'] is False
+    assert result['mqtt_has_password'] is False
+
+
+def test_perform_full_scan_aggregates_results():
+    with patch.object(ss, 'scan_open_ports', return_value=[22]), \
+         patch.object(ss, 'check_ssl_certificate', return_value=10), \
+         patch.object(ss, 'check_mqtt_security', return_value=True), \
+         patch.object(ss, 'check_cloudflare', return_value=True), \
+         patch.object(ss, 'check_duckdns', return_value=True), \
+         patch.object(ss, 'parse_configuration', return_value={'http_ssl': True}), \
+         patch.object(ss, 'get_ssh_addon_details', return_value={'running': True}), \
+         patch.object(ss, 'get_core_info', return_value={'version': '1.0'}):
+        results = ss.perform_full_scan('example.com', 'token', 'sub.domain', '/tmp/config')
+    assert results['open_ports'] == [22]
+    assert results['ssl_days_left'] == 10
+    assert results['mqtt_secure'] is True
+    assert results['cloudflare_protected'] is True
+    assert results['duckdns_match'] is True
+    assert results['config_security'] == {'http_ssl': True}
+    assert results['ssh_addon'] == {'running': True}
+    assert results['core'] == {'version': '1.0'}


### PR DESCRIPTION
## Summary
- add simple pytest tests for back-end modules
- document how to run the tests
- run the test suite in GitHub Actions on pushes and PRs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684493edd16c8330a4145f9388dd5c76