### PR TITLE
Add empty init for back package

### DIFF
--- a/hass_security_dashboard/back/__init__.py
+++ b/hass_security_dashboard/back/__init__.py
@@ -1,1 +1,0 @@
-# Package init


### PR DESCRIPTION
## Summary
- ensure `back` is treated as a package by leaving an empty `__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684496118cf48330a177cae018c2ef8b