### PR TITLE
Remove numpy from Dockerfile

### DIFF
--- a/hass_security_dashboard/Dockerfile
+++ b/hass_security_dashboard/Dockerfile
@@ -10,7 +10,6 @@ COPY requirements.txt .
 RUN apk add --no-cache \
         python3 \
         py3-pip \
-        py3-numpy \
         gcc && \
     pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- remove py3-numpy from apk install list in Dockerfile

## Testing
- `pytest -q`
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844a9044ba08330b7e02636d8bc3182