### PR TITLE
Add dockerignore for leaner builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Ignore Python cache and egg files
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Ignore Git and GitHub metadata
+.git/
+.github/
+
+# Ignore tests and test caches
+tests/
+.pytest_cache/
+
+# Ignore editor directories and OS files
+.vscode/
+.idea/
+.DS_Store
+
+# Ignore other development artifacts
+.env
+


### PR DESCRIPTION
## Summary
- prevent dev files from being sent to Docker by adding a `.dockerignore`
- `.dockerignore` ignores tests, `.github`, `.pytest_cache`, and other local artifacts

## Testing
- `pytest -q`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a977395c833086ac326ef776d27b