### PR TITLE
Use domain for SSL certificate check

### DIFF
--- a/hass_security_dashboard/back/security_scanner.py
+++ b/hass_security_dashboard/back/security_scanner.py
@@ -129,7 +129,15 @@ def perform_full_scan(domain, api_token, duckdns_domain=None, config_path=None):
     logger.info("Starting full scan")
     host = "localhost"
     open_ports = scan_open_ports(host)
-    ssl_days_left = check_ssl_certificate(host)
+
+    # Prefer the external domains for SSL checks when provided
+    ssl_host = host
+    if duckdns_domain:
+        ssl_host = duckdns_domain
+    elif domain:
+        ssl_host = domain
+    ssl_days_left = check_ssl_certificate(ssl_host)
+
     mqtt_secure = check_mqtt_security(host)
 
     cloudflare_protected = False


### PR DESCRIPTION
## Summary
- check SSL certificates against duckdns or normal domain when running a full scan
- verify perform_full_scan passes the domain parameter when calling check_ssl_certificate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a9f8ad908330be120d8928dfd6bf