### PR TITLE
Update Dockerfile for C extension builds

### DIFF
--- a/hass_security_dashboard/Dockerfile
+++ b/hass_security_dashboard/Dockerfile
@@ -10,6 +10,8 @@ COPY requirements.txt .
 RUN apk add --no-cache \
         python3 \
         py3-pip \
+        python3-dev \
+        musl-dev \
         gcc && \
     pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- add python3-dev and musl-dev packages to Dockerfile

## Testing
- `apk add --no-cache python3 py3-pip python3-dev musl-dev gcc && pip3 install --no-cache-dir -r requirements.txt` *(fails: `apk` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab991cec8330b75eb0c035957f82