### PR TITLE
Remove APScheduler from requirements

### DIFF
--- a/hass_security_dashboard/requirements.txt
+++ b/hass_security_dashboard/requirements.txt
@@ -1,5 +1,4 @@
 Flask
-APScheduler
 requests
 paho-mqtt
 PyYAML


### PR DESCRIPTION
## Summary
- drop unused APScheduler dependency

## Testing
- `pytest -q`
- `flask run -p 5000 -h 127.0.0.1` *(fails: `bash: flask: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac005db48330b9aa8cb197a90577