### PR TITLE
Update run script execution

### DIFF
--- a/hass_security_dashboard/Dockerfile
+++ b/hass_security_dashboard/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache \
     pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN chmod +x /app/run.sh
 
-CMD ["bash", "/app/run.sh"]
+CMD ["/app/run.sh"]
 

--- a/tests/test_run_environment.py
+++ b/tests/test_run_environment.py
@@ -1,0 +1,38 @@
+import os
+import json
+import subprocess
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+CONFIG_PATH = os.path.join(ROOT, "hass_security_dashboard", "config.json")
+
+options = json.load(open(CONFIG_PATH))["options"]
+
+shell_script = f'''
+set -e
+bashio::config() {{
+    case "$1" in
+        port) echo "{options['port']}" ;;
+        use_ingress) echo "{str(options['use_ingress']).lower()}" ;;
+        cloudflare_api_token) echo "{options['cloudflare_api_token']}" ;;
+        duckdns_domain) echo "{options['duckdns_domain']}" ;;
+        config_path) echo "{options['config_path']}" ;;
+    esac
+}}
+flask() {{
+    echo "PORT=$PORT"
+    echo "CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN"
+    echo "DUCKDNS_DOMAIN=$DUCKDNS_DOMAIN"
+    echo "CONFIG_PATH=$CONFIG_PATH"
+}}
+source hass_security_dashboard/run.sh
+'''
+
+result = subprocess.run(['bash', '-c', shell_script], capture_output=True, text=True)
+output = dict(line.split('=', 1) for line in result.stdout.strip().splitlines())
+
+
+def test_run_sh_uses_config_values():
+    assert output['PORT'] == str(options['port'])
+    assert output['CLOUDFLARE_API_TOKEN'] == options['cloudflare_api_token']
+    assert output['DUCKDNS_DOMAIN'] == options['duckdns_domain']
+    assert output['CONFIG_PATH'] == options['config_path']


### PR DESCRIPTION
## Summary
- mark run.sh executable inside Dockerfile
- simplify Dockerfile CMD to rely on shebang
- add regression test to ensure run.sh reads config values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68454f986120833092b2f07fb4f8fa78