### PR TITLE
Add cloudflare domain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This add-on scans your Home Assistant server and ecosystem for security vulnerab
 Edit `config.json` or the add-on options in Home Assistant:
 
 - `cloudflare_api_token` – API token for checking Cloudflare protection.
+- `cloudflare_domain` – Domain served via Cloudflare to verify and use for SSL checks.
 - `duckdns_domain` – DuckDNS hostname to verify against your public IP.
 - `config_path` – Path to `configuration.yaml` for security parsing.
 

--- a/hass_security_dashboard/config.json
+++ b/hass_security_dashboard/config.json
@@ -19,6 +19,7 @@
     "port": 5000,
     "use_ingress": true,
     "cloudflare_api_token": "",
+    "cloudflare_domain": "",
     "duckdns_domain": "",
     "config_path": "/config/configuration.yaml"
   },
@@ -26,6 +27,7 @@
     "port": "int",
     "use_ingress": "bool",
     "cloudflare_api_token": "str?",
+    "cloudflare_domain": "str?",
     "duckdns_domain": "str?",
     "config_path": "str?"
   },

--- a/hass_security_dashboard/run.sh
+++ b/hass_security_dashboard/run.sh
@@ -5,6 +5,7 @@ export FLASK_APP=back/app.py
 export PORT="${PORT:-$(bashio::config 'port')}"
 export USE_INGRESS="${USE_INGRESS:-$(bashio::config 'use_ingress')}"
 export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$(bashio::config 'cloudflare_api_token')}"
+export CLOUDFLARE_DOMAIN="${CLOUDFLARE_DOMAIN:-$(bashio::config 'cloudflare_domain')}"
 export DUCKDNS_DOMAIN="${DUCKDNS_DOMAIN:-$(bashio::config 'duckdns_domain')}"
 export CONFIG_PATH="${CONFIG_PATH:-$(bashio::config 'config_path')}"
 

--- a/tests/test_run_environment.py
+++ b/tests/test_run_environment.py
@@ -14,6 +14,7 @@ bashio::config() {{
         port) echo "{options['port']}" ;;
         use_ingress) echo "{str(options['use_ingress']).lower()}" ;;
         cloudflare_api_token) echo "{options['cloudflare_api_token']}" ;;
+        cloudflare_domain) echo "{options['cloudflare_domain']}" ;;
         duckdns_domain) echo "{options['duckdns_domain']}" ;;
         config_path) echo "{options['config_path']}" ;;
     esac
@@ -21,6 +22,7 @@ bashio::config() {{
 flask() {{
     echo "PORT=$PORT"
     echo "CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN"
+    echo "CLOUDFLARE_DOMAIN=$CLOUDFLARE_DOMAIN"
     echo "DUCKDNS_DOMAIN=$DUCKDNS_DOMAIN"
     echo "CONFIG_PATH=$CONFIG_PATH"
 }}
@@ -34,5 +36,6 @@ output = dict(line.split('=', 1) for line in result.stdout.strip().splitlines())
 def test_run_sh_uses_config_values():
     assert output['PORT'] == str(options['port'])
     assert output['CLOUDFLARE_API_TOKEN'] == options['cloudflare_api_token']
+    assert output['CLOUDFLARE_DOMAIN'] == options['cloudflare_domain']
     assert output['DUCKDNS_DOMAIN'] == options['duckdns_domain']
     assert output['CONFIG_PATH'] == options['config_path']


### PR DESCRIPTION
## Summary
- allow specifying `cloudflare_domain` in add-on config
- export `CLOUDFLARE_DOMAIN` in `run.sh`
- document new option in README
- update environment tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845504aa1e483309b8a2208c75746e8