### PR TITLE
Fix Docker install failure

### DIFF
--- a/hass_security_dashboard/Dockerfile
+++ b/hass_security_dashboard/Dockerfile
@@ -9,10 +9,7 @@ COPY requirements.txt .
 
 RUN apk add --no-cache \
         python3 \
-        py3-pip \
-        python3-dev \
-        musl-dev \
-        gcc && \
+        py3-pip && \
     pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## Summary
- simplify the Dockerfile so installation packages succeed during build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455131a9f0833084a0fc93e610ceda