### PR TITLE
Update Dockerfile with build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ Use `pytest` to run the test suite:
 pytest
 ```
 
+### Troubleshooting
+If the Docker build fails while installing Python packages, ensure build
+dependencies are present. The Dockerfile now installs `gcc`, `musl-dev`,
+`python3-dev`, and `libffi-dev` before running `pip3 install`.
+

--- a/hass_security_dashboard/Dockerfile
+++ b/hass_security_dashboard/Dockerfile
@@ -9,7 +9,11 @@ COPY requirements.txt .
 
 RUN apk add --no-cache \
         python3 \
-        py3-pip && \
+        py3-pip \
+        gcc \
+        musl-dev \
+        python3-dev \
+        libffi-dev && \
     pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## Summary
- add gcc, musl-dev, python3-dev, and libffi-dev to Dockerfile
- document build dependencies in README troubleshooting section

## Testing
- `pytest -q`
- *Docker build not run due to missing `docker` command*

------
https://chatgpt.com/codex/tasks/task_e_68455298d58c8330a67a399a46120aa3