### PR TITLE
Fix shebang for run.sh

### DIFF
--- a/hass_security_dashboard/run.sh
+++ b/hass_security_dashboard/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bashio
+#!/usr/bin/bashio
 export FLASK_APP=back/app.py
 
 # Read options from Hass.io configuration or environment variables


### PR DESCRIPTION
## Summary
- update shebang in `run.sh` so the add-on can start without s6-overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b1bb73b48330adb919a5594bd0e3